### PR TITLE
Prevent memory leak on CapturePreview() call

### DIFF
--- a/camera_photo.go
+++ b/camera_photo.go
@@ -68,5 +68,7 @@ func (c *Camera) CapturePreview(buffer io.Writer) error {
 		return newError("Cannot capture preview", int(res))
 
 	}
-	return copyFile(gpFile, buffer)
+	err = copyFile(gpFile, buffer)
+	C.gp_file_free(gpFile)
+	return err
 }


### PR DESCRIPTION
I've just discovered a memory leak, which is fixed by this patch.